### PR TITLE
Clarify direction vector meaning + Change `Direction::Option::Constant` to `Direction::Option::Single`

### DIFF
--- a/jabber/app/common.cpp
+++ b/jabber/app/common.cpp
@@ -170,7 +170,7 @@ void DiscMethodVisitor::operator()
 }
 
 void DirectionVisitor::operator()
-   (const Direction::Params<Constant> &op)
+   (const Direction::Params<Single> &op)
 {
    for (std::size_t i = 0; i < k_hats.size(); i++)
    {

--- a/jabber/app/common.hpp
+++ b/jabber/app/common.hpp
@@ -89,7 +89,7 @@ struct DiscMethodVisitor
 
 /**
  * @brief All visitor options for each Direction::Params, for initializing
- * wave directional vectors in \p k_hats.
+ * wavenumber vector directions in \p k_hats.
  * 
  */
 struct DirectionVisitor

--- a/jabber/app/common.hpp
+++ b/jabber/app/common.hpp
@@ -99,7 +99,7 @@ struct DirectionVisitor
    /// **Sized** vector of direction vectors for each wave.
    std::vector<std::vector<double>> &k_hats;
 
-   void operator() (const Direction::Params<Constant> &op);
+   void operator() (const Direction::Params<Single> &op);
    void operator() (const Direction::Params<RandomXYAngle> &op);
 };
 

--- a/jabber/app/config_input.cpp
+++ b/jabber/app/config_input.cpp
@@ -218,11 +218,11 @@ struct PrintDirectionVisitor
 
    const int &tab_level;
 
-   std::string operator()(const Direction::Params<Constant> &op)
+   std::string operator()(const Direction::Params<Single> &op)
    {
       const std::vector<PV> params
       ({
-         {"Type", GetName<Direction>(Constant)},
+         {"Type", GetName<Direction>(Single)},
          {"Vector", ToString(op.direction)}
       });
       return PrintParams(params, tab_level);
@@ -536,9 +536,9 @@ void TOMLConfigInput::ParseDirection
    Direction::Option option = 
                      GetOption<Direction>(in_val.at("Type").as_string());
 
-   if (option == Constant)
+   if (option == Single)
    {
-      Direction::Params<Constant> op;
+      Direction::Params<Single> op;
       op.direction = toml::get<std::vector<double>>(in_val.at("Vector"));
       opv = op;
    }

--- a/jabber/app/params.hpp
+++ b/jabber/app/params.hpp
@@ -263,8 +263,8 @@ struct Direction
 {
    enum class Option : std::uint8_t
    {
-      /// Constant direction.
-      Constant,
+      /// Single direction for all waves.
+      Single,
 
       /// Random angle in XY-plane from x-axis for each wave.
       RandomXYAngle,
@@ -279,7 +279,7 @@ struct Direction
                         static_cast<std::size_t>(Size)>
    kNames = 
    {
-      "Constant",         // Constant
+      "Single",           // Single
       "RandomXYAngle",    // RandomXYAngle
    };
 
@@ -287,7 +287,7 @@ struct Direction
    struct Params;
 
    template<>
-   struct Params<Constant>
+   struct Params<Single>
    {
       /// Wavenumber vector direction, can be non-normalized.
       std::vector<double> direction;
@@ -312,7 +312,7 @@ struct Direction
       int seed;
    };
 
-   using ParamsVariant = std::variant<Params<Constant>, Params<RandomXYAngle>>;
+   using ParamsVariant = std::variant<Params<Single>, Params<RandomXYAngle>>;
 
 };
 

--- a/jabber/app/params.hpp
+++ b/jabber/app/params.hpp
@@ -255,7 +255,9 @@ struct DiscMethod
 
 // ----------------------------------------------------------------------------
 /**
- * @brief All options and parameters associated with direction specification.
+ * @brief All options and parameters associated with wavenumber vector 
+ * direction specification for a set of waves as in 
+ * \p Source::Params<Source::Option::PSD>.
  */
 struct Direction
 {
@@ -287,17 +289,23 @@ struct Direction
    template<>
    struct Params<Constant>
    {
-      /// Planar wave directional vector, can be non-normalized.
+      /// Wavenumber vector direction, can be non-normalized.
       std::vector<double> direction;
    };
 
    template<>
    struct Params<RandomXYAngle>
    {
-      /// Min angle of wave from x-axis, in XY-plane (CCW+, CW-) (in degrees).
+      /**
+       * @brief Min angle of wavenumber vector from x-axis, in XY-plane
+       * (CCW+, CW-) (in degrees).
+       */
       double min_angle;
 
-      /// Max angle of wave from x-axis, in XY-plane (CCW+, CW-) (in degrees).
+      /**
+       * @brief Max angle of wavenumber vector from x-axis, in XY-plane 
+       * (CCW+, CW-) (in degrees).
+       */
       double max_angle;
 
       /// Seed to use in randomization.
@@ -425,7 +433,7 @@ struct Source
       /// Phase, in deg.
       double phase;
 
-      /// Planar wave directional vector, can be non-normalized.
+      /// Wavenumber vector direction, can be non-normalized.
       std::vector<double> direction;
 
       /// Wave speed ('S' or 'F').
@@ -444,7 +452,7 @@ struct Source
       /// Phases, in deg.
       std::vector<double> phases;
 
-      /// Planar wave directional vector, can be non-normalized.
+      /// Wavenumber vector directions, can be non-normalized.
       std::vector<std::vector<double>> directions;
 
       /// Wave speeds ('S' or 'F').
@@ -476,7 +484,7 @@ struct Source
       /// Frequency discretization method parameters.
       DiscMethod::ParamsVariant disc_params;
 
-      /// Wave direction parameters.
+      /// Wavenumber direction parameters.
       Direction::ParamsVariant dir_params;
 
       /// Seed to use for wave phase randomization.

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -30,7 +30,7 @@ struct Wave
    /// Wave speed ('S' or 'F').
    char speed;
 
-   /// **Normalized** wave directional vector.
+   /// **Normalized** wavenumber vector direction.
    std::vector<double> k_hat;
 };
 

--- a/tests/test_app_utils.hpp
+++ b/tests/test_app_utils.hpp
@@ -100,9 +100,9 @@ T::ParamsVariant GetRandomParams
    else if constexpr (std::same_as<T,Direction>)
    {
       using enum Direction::Option;
-      if (option == Constant)
+      if (option == Single)
       {
-         Direction::Params<Constant> op;
+         Direction::Params<Single> op;
          const int dim = random(1,3).get();
          op.direction = chunk(dim, random(0.0,1.0)).get();
          opv = op;
@@ -354,7 +354,7 @@ std::string TOMLWriteParams
       else if constexpr (std::same_as<T,Direction>)
       {
          using enum Direction::Option;
-         if constexpr (V == Constant)
+         if constexpr (V == Single)
          {
             out_params.emplace("Vector", TOMLWriteValue(op.direction));
          }
@@ -525,7 +525,7 @@ void TestParamsEqual
          {
             using enum Direction::Option;
 
-            if constexpr (V1 == Constant)
+            if constexpr (V1 == Single)
             {
                CHECK_THAT(op1.direction, Equals(op2.direction));
             }


### PR DESCRIPTION
This PR clarifies that the directional vector to be set, particularly for PSD source inputs, is the wavenumber vector direction. Additionally, it changes `Direction::Constant` to `Direction::Single`, as this is a more descriptive and appropriate name for what it refers to.