### PR TITLE
Remove mesh access region setting for preCICE in config file

### DIFF
--- a/apps/jabber_participant.cpp
+++ b/apps/jabber_participant.cpp
@@ -80,17 +80,34 @@ int main(int argc, char *argv[])
    // Get the preCICE input
    const PreciceParams &precice_conf = *(conf.Precice());
 
+   // Use the dim based on the base flow freestream velocity
+   const int dim = conf.BaseFlow().U.size();
+
    // Initialize preCICE participant
    precice::Participant participant(precice_conf.participant_name,
                                     precice_conf.config_file, rank, size);
+
+   // Set mesh access region [-inf,inf]
+   const std::vector<double> mesh_access_region =
+      [&]()
+   {
+      std::vector<double> acc(2*dim);
+      for (int i = 0; i < acc.size(); i++)
+      {
+         acc[i] = (i % 2 == 0)
+                  ?  std::numeric_limits<double>::lowest()
+                  :  std::numeric_limits<double>::max();
+      }
+      return acc;
+   }
+   ();
    participant.setMeshAccessRegion(precice_conf.fluid_mesh_name,
-                                   precice_conf.mesh_access_region);
+                                   mesh_access_region);
    participant.initialize();
 
    // Get mesh information from fluid participant
-   int dim = participant.getMeshDimensions(precice_conf.fluid_mesh_name);
-   int vertex_size = participant.getMeshVertexSize(
-                        precice_conf.fluid_mesh_name);
+   const int vertex_size =
+      participant.getMeshVertexSize(precice_conf.fluid_mesh_name);
    std::vector<double> coords(dim*vertex_size);
    std::vector<int> vertex_ids(vertex_size);
    participant.getMeshVertexIDsAndCoordinates(precice_conf.fluid_mesh_name,

--- a/config_template.toml
+++ b/config_template.toml
@@ -71,5 +71,4 @@ Kernel="GridPoint"
 [preCICE]
 ParticipantName="Jabber"
 ConfigFile="../precice-config.xml"
-MeshAccessRegion=[-0.01,1.01, -0.01,1.01]
 FluidMeshName="InletSponge"

--- a/jabber/app/config_input.cpp
+++ b/jabber/app/config_input.cpp
@@ -428,8 +428,7 @@ void ConfigInput::PrintPreciceParams(std::ostream &out) const
       {
          {"Participant Name",   precice_->participant_name},
          {"Config File",        precice_->config_file},
-         {"Fluid Mesh Name",    precice_->fluid_mesh_name},
-         {"Mesh Access Region", ToString(precice_->mesh_access_region)}
+         {"Fluid Mesh Name",    precice_->fluid_mesh_name}
       });
 
       out << PrintParams(params) << std::endl;
@@ -708,8 +707,6 @@ void TOMLConfigInput::ParsePrecice
                          .as_string();
    op.config_file = in_val.at("ConfigFile").as_string();
    op.fluid_mesh_name = in_val.at("FluidMeshName").as_string();
-   op.mesh_access_region =
-      toml::get<std::vector<double>>(in_val.at("MeshAccessRegion"));
 }
 
 TOMLConfigInput::TOMLConfigInput(std::string config_file, std::ostream *out)

--- a/jabber/app/params.hpp
+++ b/jabber/app/params.hpp
@@ -555,12 +555,6 @@ struct PreciceParams
 
    /// Name of mesh to get coordinates from for computation onto.
    std::string fluid_mesh_name;
-
-   /**
-    * @brief Mesh access region, defined according to
-    * precice::Participant::setMeshAccessRegion()
-    */
-   std::vector<double> mesh_access_region;
 };
 
 // ----------------------------------------------------------------------------

--- a/tests/test_app_config_input.cpp
+++ b/tests/test_app_config_input.cpp
@@ -110,23 +110,19 @@ TEST_CASE("TOMLConfigInput::ParsePrecice", "[App][TOMLConfigInput]")
    constexpr std::string_view kPartName = "TestParticipant";
    constexpr std::string_view kConfigFile = "TestConfig.xml";
    constexpr std::string_view kFluidMesh = "TestFluidMesh";
-   const std::vector<double> kMeshRegion = {-0.01, 1.01, -1.01, 1.01};
 
    const std::string precice_str =
       std::format(R"(
                      ParticipantName="{}"
                      ConfigFile="{}"
-                     MeshAccessRegion=[{},{},{},{}]
                      FluidMeshName="{}"
-                  )", kPartName, kConfigFile, kMeshRegion[0], kMeshRegion[1],
-                  kMeshRegion[2], kMeshRegion[3], kFluidMesh);
+                  )", kPartName, kConfigFile, kFluidMesh);
 
    PreciceParams params;
    TOMLConfigInput::ParsePrecice(precice_str, params);
    CHECK(params.participant_name == kPartName);
    CHECK(params.config_file == kConfigFile);
    CHECK(params.fluid_mesh_name == kFluidMesh);
-   CHECK_THAT(params.mesh_access_region, Equals(kMeshRegion));
 }
 
 } // jabber_test


### PR DESCRIPTION
This PR removes the need to specify a mesh access region, as the participant app handles mesh decomposition assuming the entire grid is accessed.

The app is updated to create an extents vector from `std::numeric_limits<double::lowest()` to `std::numeric_limits<double>::max()`