### PR TITLE
Add `ComputeWavenumber` function

### DIFF
--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -65,9 +65,9 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
 {
    // Compute denom = U·k_hat±c
    double denom = (wave.speed == 'S' ? -c_infty : c_infty);
-   for (int d = 0; d < Dim(); d++)
+   for (int d = 0; d < U_infty.size(); d++)
    {
-      denom += U_infty_[d]*wave.k_hat[d];
+      denom += U_infty[d]*wave.k_hat[d];
    }
 
    return 2*M_PI*wave.frequency/denom;

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -60,8 +60,8 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves)
 }
 
 double ComputeWavenumber(const std::vector<double> &U_infty,
-                           const double &c_infty,
-                           const Wave &wave)
+                         const double &c_infty,
+                         const Wave &wave)
 {
    // Compute denom = U·k_hat±c
    double denom = (wave.speed == 'S' ? -c_infty : c_infty);
@@ -73,7 +73,7 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
    if (denom <= 0.0)
    {
       throw std::invalid_argument(
-               "Invalid wave orientation for given freestream.");
+         "Invalid wave orientation for given freestream.");
    }
 
    return 2*M_PI*wave.frequency/denom;

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -61,13 +61,15 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves)
 
 double ComputeWavenumber(const std::vector<double> &U_infty,
                          const double &c_infty,
-                         const Wave &wave)
+                         const double &wave_freq,
+                         const std::vector<double> &wave_k_hat,
+                         const char &wave_speed)
 {
    // Compute denom = U·k_hat±c
-   double denom = (wave.speed == 'S' ? -c_infty : c_infty);
+   double denom = (wave_speed == 'S' ? -c_infty : c_infty);
    for (int d = 0; d < U_infty.size(); d++)
    {
-      denom += U_infty[d]*wave.k_hat[d];
+      denom += U_infty[d]*wave_k_hat[d];
    }
 
    if (denom <= 0.0)
@@ -76,7 +78,7 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
          "Invalid wave orientation for given freestream.");
    }
 
-   return 2*M_PI*wave.frequency/denom;
+   return 2*M_PI*wave_freq/denom;
 }
 
 

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -70,6 +70,12 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
       denom += U_infty[d]*wave.k_hat[d];
    }
 
+   if (denom <= 0.0)
+   {
+      throw std::invalid_argument(
+               "Invalid wave orientation for given freestream.");
+   }
+
    return 2*M_PI*wave.frequency/denom;
 }
 

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -124,18 +124,16 @@ void AcousticField::Finalize()
       kernel_args_.rhoE_coeffs[w] = wave.amplitude/(gamma_ - 1.0);
       kernel_args_.wave_omegas[w] = 2*M_PI*wave.frequency;
 
-      // Compute denom = U·k_hat±c and set rhoV_coeffs
-      double denom = (wave.speed == 'S' ? -c_infty_ : c_infty_);
+      // Compute rhoV_coeffs
       const int speed_encoder = (wave.speed == 'S' ? -1 : 1);
       for (int d = 0; d < Dim(); d++)
       {
-         denom += U_infty_[d]*wave.k_hat[d];
          kernel_args_.rhoV_coeffs[d*NumWaves() + w] =
             speed_encoder*wave.k_hat[d]*wave.amplitude/(rho_infty_*c_infty_);
       }
 
       // Compute magnitude of wavelength vector k
-      const double k = kernel_args_.wave_omegas[w]/denom;
+      const double k = ComputeWavenumber(U_infty_, c_infty_, wave);
 
       // Compute + set k·x+φ
       for (std::size_t i = 0; i < NumPoints(); i++)

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -59,6 +59,21 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves)
    }
 }
 
+double ComputeWavenumber(const std::vector<double> &U_infty,
+                           const double &c_infty,
+                           const Wave &wave)
+{
+   // Compute denom = U·k_hat±c
+   double denom = (wave.speed == 'S' ? -c_infty : c_infty);
+   for (int d = 0; d < Dim(); d++)
+   {
+      denom += U_infty_[d]*wave.k_hat[d];
+   }
+
+   return 2*M_PI*wave.frequency/denom;
+}
+
+
 AcousticField::AcousticField(int dim, std::span<const double> coords,
                              double p_infty, double rho_infty,
                              const std::vector<double> U_infty, double gamma,

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -168,7 +168,7 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
  *
  * @param U_infty     Freestream velocity vector.
  * @param c_infty     Freestream speed-of-sound,
- *                    $c_\infty=\sqrt{\gamma p_\infty/\rho}
+ *                    \f$c_\infty=\sqrt{\gamma p_\infty/\rho}
  *                              =\sqrt{\gamma R T_\infty}\f$.
  * @param wave_freq   Wave frequency.
  * @param wave_k_hat  Wave wavenumber orientation. **Note that

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -187,9 +187,9 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
  *
  * @details **Note that `wave.k_hat.size() == U_infty.size()`**.
  */
-double ComputeWavenumber(const std::vector<double> &U_infty,
-                         const double &c_infty,
-                         const Wave &wave)
+inline double ComputeWavenumber(const std::vector<double> &U_infty,
+                                const double &c_infty,
+                                const Wave &wave)
 {
    return ComputeWavenumber(U_infty, c_infty, wave.frequency, wave.k_hat,
                             wave.speed);

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -159,13 +159,13 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
 /**
  * @brief Compute the wavenumber vector magnitude for a given
  * \ref Wave.
- * 
+ *
  * @details Evaluates the dispersion relation
- * 
+ *
  * \f[
  *    ||\vec{k}||=\frac{2\pi f}{\hat{k}\cdot\vec{U}_\infty \pm c_\infty}.
  * \f]
- * 
+ *
  * @param U_infty    Freestream velocity vector.
  * @param c_infty    Freestream speed-of-sound,
  *                   $c_\infty=\sqrt{\gamma p_\infty/\rho}
@@ -174,8 +174,8 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
  *                   `wave.k_hat.size() == U_infty.size()`**.
  */
 double ComputeWavenumber(const std::vector<double> &U_infty,
-                           const double &c_infty,
-                           const Wave &wave);
+                         const double &c_infty,
+                         const Wave &wave);
 
 /**
  * @brief Class for specifying and computing a broadband-spectrum acoustic

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -165,6 +165,13 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
  * \f[
  *    ||\vec{k}||=\frac{2\pi f}{\hat{k}\cdot\vec{U}_\infty \pm c_\infty}.
  * \f]
+ * 
+ * @param U_infty    Freestream velocity vector.
+ * @param c_infty    Freestream speed-of-sound,
+ *                   $c_\infty=\sqrt{\gamma p_\infty/\rho}
+ *                            =\sqrt{\gamma R T_\infty}\f$.
+ * @param wave       Wave struct to compute wavenumber for. **Note that
+ *                   `wave.k_hat.size() == U_infty.size()`**.
  */
 double ComputeWavenumber(const std::vector<double> &U_infty,
                            const double &c_infty,

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -157,6 +157,20 @@ void WriteWaves(std::span<const Wave> waves, std::ostream &out);
 void ReadWaves(std::istream &in, std::vector<Wave> &waves);
 
 /**
+ * @brief Compute the wavenumber vector magnitude for a given
+ * \ref Wave.
+ * 
+ * @details Evaluates the dispersion relation
+ * 
+ * \f[
+ *    ||\vec{k}||=\frac{2\pi f}{\hat{k}\cdot\vec{U}_\infty \pm c_\infty}.
+ * \f]
+ */
+double ComputeWavenumber(const std::vector<double> &U_infty,
+                           const double &c_infty,
+                           const Wave &wave);
+
+/**
  * @brief Class for specifying and computing a broadband-spectrum acoustic
  * field onto a provided grid and base flow.
  *

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -157,8 +157,8 @@ void WriteWaves(std::span<const Wave> waves, std::ostream &out);
 void ReadWaves(std::istream &in, std::vector<Wave> &waves);
 
 /**
- * @brief Compute the wavenumber vector magnitude for a given
- * \ref Wave.
+ * @brief Compute the wavenumber vector magnitude for given freestream and
+ * wave properties.
  *
  * @details Evaluates the dispersion relation
  *
@@ -166,16 +166,34 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
  *    ||\vec{k}||=\frac{2\pi f}{\hat{k}\cdot\vec{U}_\infty \pm c_\infty}.
  * \f]
  *
- * @param U_infty    Freestream velocity vector.
- * @param c_infty    Freestream speed-of-sound,
- *                   $c_\infty=\sqrt{\gamma p_\infty/\rho}
- *                            =\sqrt{\gamma R T_\infty}\f$.
- * @param wave       Wave struct to compute wavenumber for. **Note that
- *                   `wave.k_hat.size() == U_infty.size()`**.
+ * @param U_infty     Freestream velocity vector.
+ * @param c_infty     Freestream speed-of-sound,
+ *                    $c_\infty=\sqrt{\gamma p_\infty/\rho}
+ *                              =\sqrt{\gamma R T_\infty}\f$.
+ * @param wave_freq   Wave frequency.
+ * @param wave_k_hat  Wave wavenumber orientation. **Note that
+ *                   `wave_k_hat.size() == U_infty.size()`**.
+ * @param wave_speed  Wave speed. 'S' for slow, 'F' for fast.
  */
 double ComputeWavenumber(const std::vector<double> &U_infty,
                          const double &c_infty,
-                         const Wave &wave);
+                         const double &wave_freq,
+                         const std::vector<double> &wave_k_hat,
+                         const char &wave_speed);
+
+/**
+ * @brief Compute the wavenumber vector magnitude for a given
+ * \ref Wave. See \ref ComputeWavenumber().
+ *
+ * @details **Note that `wave.k_hat.size() == U_infty.size()`**.
+ */
+double ComputeWavenumber(const std::vector<double> &U_infty,
+                         const double &c_infty,
+                         const Wave &wave)
+{
+   return ComputeWavenumber(U_infty, c_infty, wave.frequency, wave.k_hat,
+                            wave.speed);
+}
 
 /**
  * @brief Class for specifying and computing a broadband-spectrum acoustic

--- a/tests/test_wave.cpp
+++ b/tests/test_wave.cpp
@@ -51,4 +51,31 @@ TEST_CASE("Read + write Waves", "[Wave]")
    }
 }
 
+TEST_CASE("Compute wavenumber k", "[Wave][AcousticField]")
+{
+   const std::vector<double> U_infty({2*std::sqrt(2), std::sqrt(2)});
+   constexpr double c_infty = 1.0;
+
+   Wave test_wave;
+   test_wave.amplitude = 0.0;
+   test_wave.frequency = 1.0/(2*M_PI);
+   test_wave.phase = 0.0;
+   test_wave.k_hat = std::vector<double>({std::cos(M_PI_4), 
+                                          std::sin(M_PI_4)});
+
+   SECTION("Slow")
+   {
+      test_wave.speed = 'S';
+      REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave), 
+                     WithinULP(1.0/2.0, 5));
+   }
+
+   SECTION("Fast")
+   {
+      test_wave.speed = 'F';
+      REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave), 
+                     WithinULP(1.0/4.0, 5));
+   }
+}
+
 } // jabber_test

--- a/tests/test_wave.cpp
+++ b/tests/test_wave.cpp
@@ -76,6 +76,18 @@ TEST_CASE("Compute wavenumber k", "[Wave][AcousticField]")
       REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave), 
                      WithinULP(1.0/4.0, 5));
    }
+
+   SECTION("Invalid wavenumber orientation")
+   {
+      test_wave.speed = 'S';
+      std::for_each(test_wave.k_hat.begin(), test_wave.k_hat.end(),
+      [](double &k_i)
+      {
+         k_i *= -1.0;
+      });
+
+      REQUIRE_THROWS(ComputeWavenumber(U_infty, c_infty, test_wave));
+   }
 }
 
 } // jabber_test

--- a/tests/test_wave.cpp
+++ b/tests/test_wave.cpp
@@ -60,28 +60,28 @@ TEST_CASE("Compute wavenumber k", "[Wave][AcousticField]")
    test_wave.amplitude = 0.0;
    test_wave.frequency = 1.0/(2*M_PI);
    test_wave.phase = 0.0;
-   test_wave.k_hat = std::vector<double>({std::cos(M_PI_4), 
+   test_wave.k_hat = std::vector<double>({std::cos(M_PI_4),
                                           std::sin(M_PI_4)});
 
    SECTION("Slow")
    {
       test_wave.speed = 'S';
-      REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave), 
-                     WithinULP(1.0/2.0, 5));
+      REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave),
+                   WithinULP(1.0/2.0, 5));
    }
 
    SECTION("Fast")
    {
       test_wave.speed = 'F';
-      REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave), 
-                     WithinULP(1.0/4.0, 5));
+      REQUIRE_THAT(ComputeWavenumber(U_infty, c_infty, test_wave),
+                   WithinULP(1.0/4.0, 5));
    }
 
    SECTION("Invalid wavenumber orientation")
    {
       test_wave.speed = 'S';
       std::for_each(test_wave.k_hat.begin(), test_wave.k_hat.end(),
-      [](double &k_i)
+                    [](double &k_i)
       {
          k_i *= -1.0;
       });


### PR DESCRIPTION
This PR adds a simple separate function from `AcousticField` for computing the wavenumber, given a freestream velocity, freestream speed-of-sound, and either individual wave properties or a `Wave` struct (depending on overload used). An error is also now thrown for an invalid freestream/wave combination.

The evaluation is used in `AcousticField` is updated to use this new function. A unit test is included.