### PR TITLE
Use `std::span` + `const std::span &` more where appropriate

### DIFF
--- a/jabber/app/common.cpp
+++ b/jabber/app/common.cpp
@@ -40,7 +40,8 @@ void PrintBanner(std::ostream &out)
    out << banner << std::endl << std::endl;
 }
 
-void Normalize(std::span<const double> vec, std::span<double> norm_vec)
+void Normalize(const std::span<const double> &vec,
+               std::span<double> norm_vec)
 {
    double sum_sq = 0.0;
    for (std::size_t i = 0; i < vec.size(); i++)

--- a/jabber/app/common.hpp
+++ b/jabber/app/common.hpp
@@ -19,7 +19,8 @@ constexpr static std::string_view LINE =
 void PrintBanner(std::ostream &out);
 
 /// Normalize the provided vector data
-void Normalize(std::span<const double> vec, std::span<double> norm_vec);
+void Normalize(const std::span<const double> &vec,
+               std::span<double> norm_vec);
 
 /**
  * @defgroup pproc_group Parameter Processing

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -59,10 +59,10 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves)
    }
 }
 
-double ComputeWavenumber(const std::vector<double> &U_infty,
+double ComputeWavenumber(std::span<const double> U_infty,
                          const double &c_infty,
                          const double &wave_freq,
-                         const std::vector<double> &wave_k_hat,
+                         std::span<const double> wave_k_hat,
                          const char &wave_speed)
 {
    // Compute denom = U·k_hat±c
@@ -84,14 +84,14 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
 
 AcousticField::AcousticField(int dim, std::span<const double> coords,
                              double p_infty, double rho_infty,
-                             const std::vector<double> U_infty, double gamma,
+                             std::span<const double> U_infty, double gamma,
                              Kernel kernel)
    : kernel_(kernel),
      dim_(dim),
      num_pts_(coords.size()/dim_),
      p_infty_(p_infty),
      rho_infty_(rho_infty),
-     U_infty_(U_infty),
+     U_infty_(U_infty.begin(), U_infty.end()),
      gamma_(gamma),
      c_infty_(std::sqrt(gamma_*p_infty_/rho_infty_)),
      coords_(dim_)

--- a/jabber/core/acoustic_field.cpp
+++ b/jabber/core/acoustic_field.cpp
@@ -11,7 +11,7 @@
 namespace jabber
 {
 
-void WriteWaves(std::span<const Wave> waves, std::ostream &out)
+void WriteWaves(const std::span<const Wave> &waves, std::ostream &out)
 {
    for (std::size_t i = 0; i < waves.size(); i++)
    {
@@ -59,10 +59,10 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves)
    }
 }
 
-double ComputeWavenumber(std::span<const double> U_infty,
+double ComputeWavenumber(const std::span<const double> &U_infty,
                          const double &c_infty,
                          const double &wave_freq,
-                         std::span<const double> wave_k_hat,
+                         const std::span<const double> &wave_k_hat,
                          const char &wave_speed)
 {
    // Compute denom = U·k_hat±c
@@ -82,10 +82,10 @@ double ComputeWavenumber(std::span<const double> U_infty,
 }
 
 
-AcousticField::AcousticField(int dim, std::span<const double> coords,
+AcousticField::AcousticField(int dim, const std::span<const double> &coords,
                              double p_infty, double rho_infty,
-                             std::span<const double> U_infty, double gamma,
-                             Kernel kernel)
+                             const std::span<const double> &U_infty,
+                             double gamma, Kernel kernel)
    : kernel_(kernel),
      dim_(dim),
      num_pts_(coords.size()/dim_),

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -146,7 +146,7 @@ struct Wave
  * @brief Write span of \ref Wave structs to \p out as a CSV, with columns
  * [Amplitude, Frequency, Phase, Speed, k_hat].
  */
-void WriteWaves(std::span<const Wave> waves, std::ostream &out);
+void WriteWaves(const std::span<const Wave> &waves, std::ostream &out);
 
 /**
  * @brief Read in Wave structs from CSV file, as outputted by
@@ -175,10 +175,10 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
  *                   `wave_k_hat.size() == U_infty.size()`**.
  * @param wave_speed  Wave speed. 'S' for slow, 'F' for fast.
  */
-double ComputeWavenumber(std::span<const double> U_infty,
+double ComputeWavenumber(const std::span<const double> &U_infty,
                          const double &c_infty,
                          const double &wave_freq,
-                         std::span<const double> wave_k_hat,
+                         const std::span<const double> &wave_k_hat,
                          const char &wave_speed);
 
 /**
@@ -340,9 +340,9 @@ public:
     * @param gamma      Base flow specific heat ratio, γ.
     * @param kernel     Kernel type to use.
     */
-   AcousticField(int dim, std::span<const double> coords,
+   AcousticField(int dim, const std::span<const double> &coords,
                  double p_infty, double rho_infty,
-                 std::span<const double> U_infty, double gamma,
+                 const std::span<const double> &U_infty, double gamma,
                  Kernel kernel=Kernel::GridPoint);
 
    /// Get the spatial dimension.

--- a/jabber/core/acoustic_field.hpp
+++ b/jabber/core/acoustic_field.hpp
@@ -175,10 +175,10 @@ void ReadWaves(std::istream &in, std::vector<Wave> &waves);
  *                   `wave_k_hat.size() == U_infty.size()`**.
  * @param wave_speed  Wave speed. 'S' for slow, 'F' for fast.
  */
-double ComputeWavenumber(const std::vector<double> &U_infty,
+double ComputeWavenumber(std::span<const double> U_infty,
                          const double &c_infty,
                          const double &wave_freq,
-                         const std::vector<double> &wave_k_hat,
+                         std::span<const double> wave_k_hat,
                          const char &wave_speed);
 
 /**
@@ -187,7 +187,7 @@ double ComputeWavenumber(const std::vector<double> &U_infty,
  *
  * @details **Note that `wave.k_hat.size() == U_infty.size()`**.
  */
-inline double ComputeWavenumber(const std::vector<double> &U_infty,
+inline double ComputeWavenumber(std::span<const double> U_infty,
                                 const double &c_infty,
                                 const Wave &wave)
 {
@@ -342,7 +342,7 @@ public:
     */
    AcousticField(int dim, std::span<const double> coords,
                  double p_infty, double rho_infty,
-                 const std::vector<double> U_infty, double gamma,
+                 std::span<const double> U_infty, double gamma,
                  Kernel kernel=Kernel::GridPoint);
 
    /// Get the spatial dimension.

--- a/jabber/core/interpolant.cpp
+++ b/jabber/core/interpolant.cpp
@@ -6,7 +6,8 @@ namespace jabber
 {
 
 
-PWLinear::PWLinear(std::span<const double> x_k, std::span<const double> y_k)
+PWLinear::PWLinear(const std::span<const double> &x_k, 
+                   const std::span<const double> &y_k)
 {
    for (std::size_t i = 1; i < x_k.size(); i++)
    {
@@ -41,7 +42,8 @@ double PWLinear::operator() (const double &x) const
    return m*(x-x_1) + y_1;
 }
 
-PWLogLog::PWLogLog(std::span<const double> x_k, std::span<const double> y_k)
+PWLogLog::PWLogLog(const std::span<const double> &x_k,
+                   const std::span<const double> &y_k)
 {
    for (std::size_t i = 1; i < x_k.size(); i++)
    {

--- a/jabber/core/interpolant.cpp
+++ b/jabber/core/interpolant.cpp
@@ -6,7 +6,7 @@ namespace jabber
 {
 
 
-PWLinear::PWLinear(const std::span<const double> &x_k, 
+PWLinear::PWLinear(const std::span<const double> &x_k,
                    const std::span<const double> &y_k)
 {
    for (std::size_t i = 1; i < x_k.size(); i++)

--- a/jabber/core/interpolant.hpp
+++ b/jabber/core/interpolant.hpp
@@ -46,7 +46,8 @@ protected:
 
 public:
    /// Construct piecewise linear interpolant through ( \p x_k , \p y_k ).
-   PWLinear(std::span<const double> x_k, std::span<const double> y_k);
+   PWLinear(const std::span<const double> &x_k, 
+            const std::span<const double> &y_k);
 
    double operator() (const double &x) const override;
 };
@@ -79,7 +80,8 @@ public:
     * @brief Construct piecewise log-log (linear in log10 space) interpolant
     * through ( \p x_k , \p y_k ).
     */
-   PWLogLog(std::span<const double> x_k, std::span<const double> y_k);
+   PWLogLog(const std::span<const double> &x_k,
+            const std::span<const double> &y_k);
 
    double operator() (const double &x) const override;
 };

--- a/jabber/core/interpolant.hpp
+++ b/jabber/core/interpolant.hpp
@@ -46,7 +46,7 @@ protected:
 
 public:
    /// Construct piecewise linear interpolant through ( \p x_k , \p y_k ).
-   PWLinear(const std::span<const double> &x_k, 
+   PWLinear(const std::span<const double> &x_k,
             const std::span<const double> &y_k);
 
    double operator() (const double &x) const override;

--- a/jabber/core/psd.cpp
+++ b/jabber/core/psd.cpp
@@ -7,7 +7,7 @@ namespace jabber
 {
 
 
-Interval Interval::ComputeInterval(std::span<const double> freqs,
+Interval Interval::ComputeInterval(const std::span<const double> &freqs,
                                    std::size_t i,
                                    Interval::Method method)
 {
@@ -66,7 +66,7 @@ Interval Interval::ComputeInterval(std::span<const double> freqs,
    }
 }
 
-void BasePSD::Discretize(std::span<const double> freqs,
+void BasePSD::Discretize(const std::span<const double> &freqs,
                          Interval::Method method,
                          std::span<double> powers) const
 {

--- a/jabber/core/psd.hpp
+++ b/jabber/core/psd.hpp
@@ -160,7 +160,7 @@ public:
     * @param method        Interval::Method enumerator.
     * @param powers        Output powers.
     */
-   void Discretize(const std::span<const double> &freqs, 
+   void Discretize(const std::span<const double> &freqs,
                    Interval::Method method,
                    std::span<double> powers) const;
 
@@ -183,7 +183,7 @@ public:
     *                 the minimum and maximum discrete frequencies provided.
     * @param psd      PSD associated with each frequency in \p freq.
     */
-   PWLinearPSD(const std::span<const double> &freq, 
+   PWLinearPSD(const std::span<const double> &freq,
                std::span<const double> psd)
       : PWLinear(freq, psd) {}
 

--- a/jabber/core/psd.hpp
+++ b/jabber/core/psd.hpp
@@ -108,7 +108,7 @@ public:
     * @param i            Index of frequency to compute interval Δf for.
     * @param method       Method to use for interval computation.
     */
-   static Interval ComputeInterval(std::span<const double> freqs,
+   static Interval ComputeInterval(const std::span<const double> &freqs,
                                    std::size_t i, Interval::Method method);
 
 
@@ -160,7 +160,8 @@ public:
     * @param method        Interval::Method enumerator.
     * @param powers        Output powers.
     */
-   void Discretize(std::span<const double> freqs, Interval::Method method,
+   void Discretize(const std::span<const double> &freqs, 
+                   Interval::Method method,
                    std::span<double> powers) const;
 
    virtual ~BasePSD() = default;
@@ -182,7 +183,8 @@ public:
     *                 the minimum and maximum discrete frequencies provided.
     * @param psd      PSD associated with each frequency in \p freq.
     */
-   PWLinearPSD(std::span<const double> freq, std::span<const double> psd)
+   PWLinearPSD(const std::span<const double> &freq, 
+               std::span<const double> psd)
       : PWLinear(freq, psd) {}
 
    double Min() const override
@@ -218,7 +220,8 @@ public:
     *                 the minimum and maximum discrete frequencies provided.
     * @param psd      PSD associated with each frequency in \p freq.
     */
-   PWLogLogPSD(std::span<const double> freq, std::span<const double> psd)
+   PWLogLogPSD(const std::span<const double> &freq,
+               std::span<const double> psd)
       : PWLogLog(freq, psd) {}
 
    double Min() const override


### PR DESCRIPTION
Generalizes further beyond `std::vector` and improves const-correctness.